### PR TITLE
v1.1.1: Fix GPT-5 model compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Send messages to OpenAI GPT models and get responses.
   - content: The message text
 - **model** - Which model to use (default: "gpt-4o"). Examples:
   - GPT-5 family: gpt-5 (complex reasoning), gpt-5-mini (cost-optimized), gpt-5-nano (high-throughput)
+    - Note: `gpt-5` or `gpt5` automatically maps to `gpt-5-chat-latest` for compatibility
   - GPT-4 family: gpt-4o, gpt-4o-mini
   - o3 family: o3, o3-mini
 - **temperature** - Creativity level from 0-2 (default: 0.7). Lower = more focused, higher = more creative

--- a/Sources/SwiftOpenAIMCPServer.swift
+++ b/Sources/SwiftOpenAIMCPServer.swift
@@ -225,6 +225,15 @@ final class OpenAIServiceWrapper: @unchecked Sendable {
     }
   }
   
+  private func normalizeModelName(_ model: String) -> String {
+    // Map gpt5 or gpt-5 to gpt-5-chat-latest
+    let lowercased = model.lowercased()
+    if lowercased == "gpt5" || lowercased == "gpt-5" {
+      return "gpt-5-chat-latest"
+    }
+    return model
+  }
+  
   private func performChatCompletion(arguments: Value?) async throws -> String {
     guard let args = arguments?.objectValue else {
       throw OpenAIServiceError.invalidArguments
@@ -251,7 +260,8 @@ final class OpenAIServiceWrapper: @unchecked Sendable {
     }
     
     // Parse optional parameters
-    let model = args["model"]?.stringValue ?? "gpt-4o"
+    let rawModel = args["model"]?.stringValue ?? "gpt-4o"
+    let model = normalizeModelName(rawModel)
     let temperature = args["temperature"]?.doubleValue
     let maxTokens = args["max_tokens"]?.intValue
     let stream = args["stream"]?.boolValue ?? false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftopenai-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MCP server for SwiftOpenAI - access OpenAI APIs through Model Context Protocol",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary
Fixes an issue where users were getting errors when using `gpt-5` or `gpt5` as the model name, while `gpt-5-chat-latest` was working correctly.

## Changes
- ✨ Added `normalizeModelName` function to automatically map model names
- 🔄 Maps `gpt-5` and `gpt5` to `gpt-5-chat-latest` for compatibility
- 📝 Updated README to document the automatic mapping behavior
- 🔖 Bumped version to 1.1.1

## Problem Solved
Users can now use the simpler model names:
- `gpt-5` or `gpt5` → automatically uses `gpt-5-chat-latest`
- `gpt-5-mini` and `gpt-5-nano` remain unchanged (work as-is)

## Test Plan
- [x] Code compiles successfully with `swift build -c release`
- [x] Model name normalization logic is simple and case-insensitive
- [ ] Test with MCP client using both `gpt-5` and `gpt5` model names

## Related Changes
This PR includes all changes from the previous commits:
- Documentation updates for npm package (v1.1.0)
- GPT-5 model compatibility fix (v1.1.1)

🤖 Generated with [Claude Code](https://claude.ai/code)